### PR TITLE
configure the hostname with the desired hostname

### DIFF
--- a/lib/beaker/hypervisor/hcloud.rb
+++ b/lib/beaker/hypervisor/hcloud.rb
@@ -74,7 +74,7 @@ module Beaker
       location = host[:location] || 'nbg1'
       server_type = host[:server_type] || 'cx11'
       action, server = @client.servers.create(
-        name: host.name,
+        name: host.hostname,
         location: location,
         server_type: server_type,
         image: host[:image],


### PR DESCRIPTION
puppet_metadata adds an attribute to each host, with the desired hostname:
https://github.com/voxpupuli/puppet_metadata/blob/master/lib/puppet_metadata/beaker.rb#L51